### PR TITLE
Remove slash to not cause double slash

### DIFF
--- a/web/js/3las/3las.js
+++ b/web/js/3las/3las.js
@@ -72,7 +72,7 @@ var _3LAS = /** @class */ (function () {
             this.WakeLock.Begin();
         try {
             if (window.location.protocol === 'https:') {
-                this.WebSocket = new WebSocketClient(this.Logger, 'wss://' + this.Settings.SocketHost + ':' + window.location.pathname + '/stream' + this.Settings.SocketPath, this.OnSocketError.bind(this), this.OnSocketConnect.bind(this), this.OnSocketDataReady.bind(this), this.OnSocketDisconnect.bind(this));
+                this.WebSocket = new WebSocketClient(this.Logger, 'wss://' + this.Settings.SocketHost + ':' + window.location.pathname + 'stream' + this.Settings.SocketPath, this.OnSocketError.bind(this), this.OnSocketConnect.bind(this), this.OnSocketDataReady.bind(this), this.OnSocketDisconnect.bind(this));
             }
             else {
                 this.WebSocket = new WebSocketClient(this.Logger, 'ws://' + this.Settings.SocketHost + ':' + this.Settings.SocketPort.toString() + this.Settings.SocketPath, this.OnSocketError.bind(this), this.OnSocketConnect.bind(this), this.OnSocketDataReady.bind(this), this.OnSocketDisconnect.bind(this));


### PR DESCRIPTION
A minor oversight from my end, 

Removing the slash helps the client not going to "//stream"
