### PR TITLE
Hotfix: 3las server listen op both ipv6 and ipv4

### DIFF
--- a/stream/3las.server.js
+++ b/stream/3las.server.js
@@ -234,7 +234,7 @@ class StreamServer {
     }
     Run() {
         this.Server = new ws.Server({
-            "host": "127.0.0.1",
+            "host": ["127.0.0.1", "::1"],
             "port": this.Port,
             "clientTracking": true,
             "perMessageDeflate": false


### PR DESCRIPTION
Hotfix: 3las server listen op both ipv6 and ipv4