### PR TITLE
auto-shutdown bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -489,7 +489,7 @@ wss.on('connection', (ws, request) => {
   const clientIp = request.headers['x-forwarded-for'] || request.connection.remoteAddress;
   currentUsers++;
   dataHandler.showOnlineUsers(currentUsers);
-  if(currentUsers > 0 && serverConfig.autoShutdown === true) {
+  if(currentUsers === 1 && serverConfig.autoShutdown === true) {
     connectToXdrd(); 
   }
 


### PR DESCRIPTION
bugfix. If someone connects even if tuner is powered on it does connectToXdrd function. Default behavior: change fx to 87.5. 
This fix causes that function is called only when 1st user connects.