### PR TITLE
fix for first client

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -113,7 +113,7 @@ function connectToXdrd() {
       
       let authFlags = {
         authMsg: false,
-        firstClient: true,
+        firstClient: false,
         receivedSalt: '',
         receivedPassword: false,
         messageCount: 0,


### PR DESCRIPTION
Previously this flag was set always on true. Which means even if someone was connected to XDRd, webserver was changing frequency to the default one (even when tuner was locked) this behavior was very annoying. Changing firstclient flag to false will let further if statements change state of this flag to true (if no one is connected already)