### PR TITLE
Fixes/v1.3.0.1 serialport reconnect fixes - 4 files

### DIFF
--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -425,6 +425,18 @@ function handleData(wss, receivedData, rdsWss) {
     }
 }
 
+// Serialport retry code when port is open but communication is lost (additional code in index.js)
+isSerialportAlive = true;
+lastFrequencyAlive = '87.500';
+setInterval(() => {
+  lastFrequencyAlive = initialData.freq;
+  // Activate serialport retry if handleData has not been executed for over 10 seconds
+  if (((Date.now() - lastUpdateTime) > 8000) && !isSerialportRetrying && serverConfig.xdrd.wirelessConnection === false) {
+    isSerialportAlive = false;
+    isSerialportRetrying = true;
+  }
+}, 2000);
+
 function showOnlineUsers(currentUsers) {
   dataToSend.users = currentUsers;
   initialData.users = currentUsers;

--- a/server/index.js
+++ b/server/index.js
@@ -126,6 +126,28 @@ function checkIPv6Support(callback) {
   });
 }
 
+// Serialport retry code when port is open but communication is lost (additional code in datahandler.js)
+isSerialportRetrying = false;
+
+setInterval(() => {
+  if (!isSerialportAlive && serverConfig.xdrd.wirelessConnection === false) {
+    isSerialportAlive = true;
+    isSerialportRetrying = true;
+    if (serialport && serialport.isOpen) {
+      logWarn('Communication lost from ' + serverConfig.xdrd.comPort + ', force closing serialport.');
+      setTimeout(() => {
+        serialport.close((err) => {
+          if (err) {
+            logError('Error closing serialport: ', err.message);
+          }
+        });
+      }, 1000);
+    } else {
+      logWarn('Communication lost from ' + serverConfig.xdrd.comPort + '.');
+    }
+  }
+}, 2000);
+
 // Serial Connection
 function connectToSerial() {
 if (serverConfig.xdrd.wirelessConnection === false) {
@@ -150,6 +172,7 @@ if (serverConfig.xdrd.wirelessConnection === false) {
     }
     
     logInfo('Using COM device: ' + serverConfig.xdrd.comPort);
+    isSerialportAlive = true;
     setTimeout(() => {
         serialport.write('x\n');
     }, 3000);
@@ -163,9 +186,12 @@ if (serverConfig.xdrd.wirelessConnection === false) {
         serialport.write('T' + Math.round(serverConfig.defaultFreq * 1000) + '\n');
         dataHandler.initialData.freq = Number(serverConfig.defaultFreq).toFixed(3);
         dataHandler.dataToSend.freq = Number(serverConfig.defaultFreq).toFixed(3);
+      } else if (lastFrequencyAlive && isSerialportRetrying) { // Serialport retry code when port is open but communication is lost
+        serialport.write('T' + (lastFrequencyAlive * 1000) + '\n');
       } else {
         serialport.write('T87500\n');
       }
+      isSerialportRetrying = false;
 
       serialport.write('A0\n');
       serialport.write('F-1\n');
@@ -190,6 +216,7 @@ if (serverConfig.xdrd.wirelessConnection === false) {
   serialport.on('close', () => {
     logWarn('Disconnected from ' + serverConfig.xdrd.comPort + '. Attempting to reconnect.');
     setTimeout(() => {
+        isSerialportRetrying = true;
         connectToSerial();
     }, 5000);
   });

--- a/web/js/3las/3las.js
+++ b/web/js/3las/3las.js
@@ -57,9 +57,11 @@ var _3LAS = /** @class */ (function () {
         audioStreamRestartInterval = setInterval(() => {
           if (requiresAudioStreamRestart) {
             requiresAudioStreamRestart = false;
-            this.Stop();
-            this.Start();
-            console.log("Audio stream restarted after radio data loss.");
+            if (Stream) {
+              this.Stop();
+              this.Start();
+              console.log("Audio stream restarted after radio data loss.");
+            }
           }
         }, 3000);
 

--- a/web/js/3las/3las.js
+++ b/web/js/3las/3las.js
@@ -1,3 +1,4 @@
+var audioStreamRestartInterval;
 var elapsedTimeConnectionWatchdog;
 var _3LAS_Settings = /** @class */ (function () {
     function _3LAS_Settings() {
@@ -47,6 +48,20 @@ var _3LAS = /** @class */ (function () {
     _3LAS.prototype.Start = function () {
         this.ConnectivityFlag = false;
         this.Stop(); // Attempt to mitigate the 0.5x speed/multiple stream bug
+
+        // Restart audio stream if radio data connection was reestablished
+        // to prevent stuttering audio in some cases
+        if (audioStreamRestartInterval) {
+            clearInterval(audioStreamRestartInterval);
+        }
+        audioStreamRestartInterval = setInterval(() => {
+          if (requiresAudioStreamRestart) {
+            requiresAudioStreamRestart = false;
+            this.Stop();
+            this.Start();
+            console.log("Audio stream restarted after radio data loss.");
+          }
+        }, 3000);
 
         // Stream connection watchdog monitors mp3 frames
         console.log("Stream connection watchdog active.");


### PR DESCRIPTION
Serialport reconnect rework.

Server-side, reconnects to microcontroller on data flow loss if port is still connected (or connection lost), and restores last frequency used.
Client-side, restarts WebSocket to unfreeze UI and restarts audio stream in case of stutters.
