### PR TITLE
Mono/Stereo symbol

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -291,7 +291,7 @@ function sendPingRequest() {
             $('#current-ping').text(`Ping: unknown`);
             if (!pingTimeLimit) { // Force reconnection as WebSocket could be unresponsive even though it's reported as OPEN
               window.socket.close(1000, 'Normal closure');
-              sendToast('warning', 'Connection lost', 'Attempting to reconnect...', false, false);
+              if (connectionLost) sendToast('warning', 'Connection lost', 'Attempting to reconnect...', false, false);
               console.log("Reconnecting due to high ping...");
               pingTimeLimit = true;
             }
@@ -311,7 +311,7 @@ function sendPingRequest() {
       if (messageCounter === 5) {
         messageCounter = 0;
         window.socket.close(1000, 'Normal closure');
-        sendToast('warning', 'Connection lost', 'Attempting to reconnect...', false, false);
+        if (connectionLost) sendToast('warning', 'Connection lost', 'Attempting to reconnect...', false, false);
         console.log("Reconnecting due to no data received...");
       }
     } else {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -290,7 +290,7 @@ function sendPingRequest() {
             console.warn('Ping request failed');
             $('#current-ping').text(`Ping: unknown`);
             if (!pingTimeLimit) { // Force reconnection as WebSocket could be unresponsive even though it's reported as OPEN
-              window.socket.close(1000, 'Normal closure');
+              if (messageLength === 0) window.socket.close(1000, 'Normal closure');
               if (connectionLost) sendToast('warning', 'Connection lost', 'Attempting to reconnect...', false, false);
               console.log("Reconnecting due to high ping...");
               pingTimeLimit = true;

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -845,7 +845,16 @@ const updateDataElements = throttle(function(parsedData) {
     }
 
     if(parsedData.stForced) {
-        stereoColor = 'gray';
+        if (!parsedData.st) {
+          stereoColor = 'gray';
+        } else {
+          stereoColor = 'var(--color-4)';
+        }
+        $('.data-st.circle1').css('left', '4px');
+        $('.data-st.circle2').css('display', 'none');
+    } else {
+        $('.data-st.circle1').css('left', '0px');
+        $('.data-st.circle2').css('display', 'block');
     }
     $dataSt.css('border', '2px solid ' + stereoColor);
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -6,8 +6,8 @@ var parsedData, signalChart, previousFreq;
 var signalData = [];
 var data = [];
 let updateCounter = 0;
-let messageCounter = 0;
-let messageData = 800; // Inital value anything above 0
+let messageCounter = 0; // Count for WebSocket data length returning 0
+let messageData = 800; // Initial value anything above 0
 let messageLength = 800; // Retain value of messageData until value is updated
 let pingTimeLimit = false; // WebSocket becomes unresponsive with high ping
 


### PR DESCRIPTION
[main.js]

1. Mono/Stereo symbol.
2. Effective solutions for unstable (mobile) internet to prevent needing a page refresh:

* More stable ping response using `cache: 'no-store'`
* Reconnect WebSocket if ping exceeds limit, socket might become unresponsive even though it's reported as OPEN.
* Reconnect WebSocket if socket message length is `0` after consecutive queries.
