### PR TITLE
Regional station name detection based on regional PI

### DIFF
--- a/server/tx_search.js
+++ b/server/tx_search.js
@@ -159,7 +159,7 @@ async function processData(data, piCode, rdsPs) {
 
     if (matchingStation) {
         return {
-            station: matchingStation.station.replace("R.", "Radio "),
+            station: detectedByPireg ? matchingStation.station.replace("R.", "Radio ") + ' ' + matchingStation.regname : matchingStation.station.replace("R.", "Radio "),
             pol: matchingStation.pol.toUpperCase(),
             erp: matchingStation.erp && matchingStation.erp > 0 ? matchingStation.erp : '?',
             city: matchingCity.name,


### PR DESCRIPTION
When a station is identified by its regional PI code, its regional name is added as part of the identified station name with this simple code change.

The operation has been successfully tested for a few months on the Finnish regional broadcasts of YLE Radio Suomi and YLE Radio Vega, as well as on a couple of Iskelmä frequencies, which have a regional PI code during regional commercials.

For example, instead of just the national name "YLE Radio Suomi", the frequency 94.3 broadcast from Turku with PI code 6703 during a regional broadcast is correctly identified as "YLE Radio Suomi Turku".