### PR TITLE
Fixes/v1.3.6.1 ffmpeg audio settings

### DIFF
--- a/server/server_config.js
+++ b/server/server_config.js
@@ -45,7 +45,9 @@ let serverConfig = {
     audioBitrate: "128k",
     audioBoost: false,
     softwareMode: false,
-    startupVolume: "0.95"
+    startupVolume: "0.95",
+    ffmpeg: false,
+    samplerateOffset: "0"
   },
   identification: {
     token: null,

--- a/server/stream/checkFFmpeg.js
+++ b/server/stream/checkFFmpeg.js
@@ -1,0 +1,23 @@
+const { spawn } = require('child_process');
+
+function checkFFmpeg() {
+  return new Promise((resolve, reject) => {
+    const checkFFmpegProcess = spawn('ffmpeg', ['-version'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+
+    checkFFmpegProcess.on('error', () => {
+      resolve(require('ffmpeg-static'));
+    });
+
+    checkFFmpegProcess.on('exit', (code) => {
+      if (code === 0) {
+        resolve('ffmpeg');
+      } else {
+        resolve(require('ffmpeg-static'));
+      }
+    });
+  });
+}
+
+module.exports = checkFFmpeg;

--- a/server/stream/index.js
+++ b/server/stream/index.js
@@ -1,59 +1,134 @@
-const { spawn } = require('child_process');
-const ffmpeg = require('ffmpeg-static');
+const { spawn, execSync } = require('child_process');
 const { configName, serverConfig, configUpdate, configSave, configExists } = require('../server_config');
 const { logDebug, logError, logInfo, logWarn, logFfmpeg } = require('../console');
-  
-function enableAudioStream() {
-    var ffmpegParams, ffmpegCommand;
-    serverConfig.webserver.webserverPort = Number(serverConfig.webserver.webserverPort);
+const checkFFmpeg = require('./checkFFmpeg');
 
-    const flags = `-fflags +nobuffer+flush_packets -flags low_delay -rtbufsize 6192 -probesize 32`;
-    const codec = `-acodec pcm_s16le -ar 48000 -ac ${serverConfig.audio.audioChannels}`;
-    const output = `${serverConfig.audio.audioBoost == true ? '-af "volume=3.5"' : ''} -f s16le -fflags +nobuffer+flush_packets -packetsize 384 -flush_packets 1 -bufsize 960`;
+let ffmpeg, ffmpegCommand, ffmpegParams;
+
+function checkAudioUtilities() {
+    if (process.platform === 'darwin') {
+        try {
+            execSync('which rec');
+            //console.log('[Audio Utility Check] SoX ("rec") found.');
+        } catch (error) {
+            logError('[Audio Utility Check] Error: SoX ("rec") not found. Please install SoX (e.g., using `brew install sox`).');
+            process.exit(1); // Exit the process with an error code
+        }
+    } else if (process.platform === 'linux') {
+        try {
+            execSync('which arecord');
+            //console.log('[Audio Utility Check] ALSA ("arecord") found.');
+        } catch (error) {
+            logError('[Audio Utility Check] Error: ALSA ("arecord") not found. Please ensure ALSA utilities are installed (e.g., using `sudo apt-get install alsa-utils` or `sudo yum install alsa-utils`).');
+            process.exit(1); // Exit the process with an error code
+        }
+    } else {
+        //console.log(`[Audio Utility Check] Platform "${process.platform}" does not require explicit checks for rec or arecord.`);
+    }
+}
+
+function buildCommand() {
+    // Common audio options for FFmpeg
+    const baseOptions = {
+        flags: '-fflags +nobuffer+flush_packets -flags low_delay -rtbufsize 6192 -probesize 32',
+        codec: `-acodec pcm_s16le -ar 48000 -ac ${serverConfig.audio.audioChannels}`,
+        output: '-f s16le -fflags +nobuffer+flush_packets -packetsize 384 -flush_packets 1 -bufsize 960'
+    };
 
     if (process.platform === 'win32') {
-        // Windows
-        ffmpegCommand = "\"" + ffmpeg.replace(/\\/g, '\\\\') + "\"";
-        ffmpegParams = `${flags} -f dshow -audio_buffer_size 200 -i audio="${serverConfig.audio.audioDevice}" ${codec} ${output} pipe:1 | node server/stream/3las.server.js -port ${serverConfig.webserver.webserverPort + 10} -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
-      } else {
-        // Linux
-        ffmpegCommand = 'ffmpeg';
-        ffmpegParams = `${flags} -f alsa -i "${serverConfig.audio.softwareMode && serverConfig.audio.softwareMode == true ? 'plug' : ''}${serverConfig.audio.audioDevice}" ${codec} ${output} pipe:1 | node server/stream/3las.server.js -port ${serverConfig.webserver.webserverPort + 10} -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
-    } 
+        // Windows: ffmpeg using dshow
+        logInfo('[Audio Stream] Platform: Windows (win32). Using "dshow" input.');
+        ffmpegCommand = `"${ffmpeg.replace(/\\/g, '\\\\')}"`;
+        return `${ffmpegCommand} ${baseOptions.flags} -f dshow -audio_buffer_size 200 -i audio="${serverConfig.audio.audioDevice}" ` +
+            `${baseOptions.codec} ${baseOptions.output} pipe:1 | node server/stream/3las.server.js -port ` +
+            `${serverConfig.webserver.webserverPort + 10} -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
+    } else if (process.platform === 'darwin') {
+        // macOS: using SoX's rec with coreaudio
+        if (!serverConfig.audio.ffmpeg) {
+            logInfo('[Audio Stream] Platform: macOS (darwin) using "coreaudio" with the default audio device.');
+            const recCommand = `rec -t coreaudio -b 32 -r 48000 -c ${serverConfig.audio.audioChannels} -t raw -b 16 -r 48000 -c ${serverConfig.audio.audioChannels} -`;
+            return `${recCommand} | node server/stream/3las.server.js -port ${serverConfig.webserver.webserverPort + 10}` + 
+            ` -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
+        } else {
+            ffmpegCommand = ffmpeg;
+            ffmpegParams = `${baseOptions.flags} -f alsa -i "${serverConfig.audio.softwareMode && serverConfig.audio.softwareMode == true ? 'plug' : ''}${serverConfig.audio.audioDevice}" ${baseOptions.codec}`;
+            ffmpegParams += ` ${baseOptions.output} -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 10 pipe:1 | node server/stream/3las.server.js -port ${serverConfig.webserver.webserverPort + 10} -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
+            return `${ffmpegCommand} ${ffmpegParams}`;
+        }
+    } else {
+        // Linux: use alsa with arecord
+        // If softwareMode is enabled, prefix the device with 'plug'
+        if (!serverConfig.audio.ffmpeg) {
+            const audioDevicePrefix = (serverConfig.audio.softwareMode && serverConfig.audio.softwareMode === true) ? 'plug' : '';
+            logInfo('[Audio Stream] Platform: Linux. Using "alsa" input.');
+            const recCommand = `while true; do arecord -D "${audioDevicePrefix}${serverConfig.audio.audioDevice}" -f S16_LE -r 48000 -c ${serverConfig.audio.audioChannels} -t raw -; done`;
+            return `${recCommand} | node server/stream/3las.server.js -port ${serverConfig.webserver.webserverPort + 10}` + 
+            ` -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
+        } else {
+            ffmpegCommand = ffmpeg;
+            ffmpegParams = `${baseOptions.flags} -f alsa -i "${serverConfig.audio.softwareMode && serverConfig.audio.softwareMode == true ? 'plug' : ''}${serverConfig.audio.audioDevice}" ${baseOptions.codec}`;
+            ffmpegParams += ` ${baseOptions.output} -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 10 pipe:1 | node server/stream/3las.server.js -port ${serverConfig.webserver.webserverPort + 10} -samplerate 48000 -channels ${serverConfig.audio.audioChannels}`;
+            return `${ffmpegCommand} ${ffmpegParams}`;
+        }
+    }
+}
 
-    logInfo("Trying to start audio stream on device: \x1b[35m" + serverConfig.audio.audioDevice);
-    logInfo(`Using internal audio network port ${serverConfig.webserver.webserverPort + 10}.`);
+function enableAudioStream() {
+    // Ensure the webserver port is a number.
+    serverConfig.webserver.webserverPort = Number(serverConfig.webserver.webserverPort);
+    let startupSuccess = false;
+    const command = buildCommand();
 
-    // If an audio device is configured, start the stream
-    if(serverConfig.audio.audioDevice.length > 2) {
-        let startupSuccess = false;
-        const childProcess = spawn(ffmpegCommand, [ffmpegParams], { shell: true });
+    // Only log audio device details if the platform is not macOS.
+    if (process.platform !== 'darwin') {
+        logInfo(`Trying to start audio stream on device: \x1b[35m${serverConfig.audio.audioDevice}\x1b[0m`);
+    }
+    else {
+        // For macOS, log the default audio device.
+        logInfo(`Trying to start audio stream on default input device.`);
+    }
+
+    logInfo(`Using internal audio network port: ${serverConfig.webserver.webserverPort + 10}`);
+    logInfo('Using', ffmpeg === 'ffmpeg' ? 'system-installed FFmpeg' : 'ffmpeg-static');
+    logDebug(`[Audio Stream] Full command:\n${command}`);
+
+    // Start the stream only if a valid audio device is configured.
+    if (serverConfig.audio.audioDevice && serverConfig.audio.audioDevice.length > 2) {
+        const childProcess = spawn(command, { shell: true });
 
         childProcess.stdout.on('data', (data) => {
-            logFfmpeg(`stdout: ${data}`);
+            logFfmpeg(`[stream:stdout] ${data}`);
         });
 
         childProcess.stderr.on('data', (data) => {
-            logFfmpeg(`stderr: ${data}`);
-            if(data.includes('I/O error')) {
-                logError('Audio device \x1b[35m' + serverConfig.audio.audioDevice + '\x1b[0m failed to start. Start server with the command \x1b[33mnode . --ffmpegdebug \x1b[0mfor more info.');
+            logFfmpeg(`[stream:stderr] ${data}`);
+
+            if (data.includes('I/O error')) {
+                logError(`[Audio Stream] Audio device "${serverConfig.audio.audioDevice}" failed to start.`);
+                logError('Please start the server with: node . --ffmpegdebug for more info.');
             }
-            if(data.includes('size=') && startupSuccess === false) {
-                logInfo('Audio stream started up successfully.');
+            if (data.includes('size=') && !startupSuccess) {
+                logInfo('[Audio Stream] Audio stream started up successfully.');
                 startupSuccess = true;
             }
         });
-    
+
         childProcess.on('close', (code) => {
-            logFfmpeg(`Child process exited with code ${code}`);
+            logFfmpeg(`[Audio Stream] Child process exited with code: ${code}`);
         });
-    
+
         childProcess.on('error', (err) => {
-            logFfmpeg(`Error starting child process: ${err}`);
+            logFfmpeg(`[Audio Stream] Error starting child process: ${err}`);
         });
+    } else {
+        logWarn('[Audio Stream] No valid audio device configured. Skipping audio stream initialization.');
     }
 }
 
 if(configExists()) {
-    enableAudioStream();
+    checkFFmpeg().then((ffmpegResult) => {
+        ffmpeg = ffmpegResult;
+        if (!serverConfig.audio.ffmpeg) checkAudioUtilities();
+        enableAudioStream();
+    });
 }

--- a/web/setup.ejs
+++ b/web/setup.ejs
@@ -217,6 +217,18 @@
                         <%- include('_components', {component: 'checkbox', cssClass: '', label: 'ALSA Software mode', id: 'audio-softwareMode'}) %>
                     </div>
                 </div>
+                <div class="flex-container">
+                    <div class="panel-50 p-bottom-20">
+                        <h3>FFmpeg</h3>
+                        <p>Legacy option for Linux / macOS that could resolve audio issues, but will consume additional CPU and RAM usage.</p>
+                        <%- include('_components', {component: 'checkbox', cssClass: '', label: 'Additional FFmpeg', id: 'audio-ffmpeg'}) %>
+                    </div>
+                    <div class="panel-50 p-bottom-20">
+                        <h3>Samplerate Offset</h3>
+                        <p>Using a negative value could eliminate audio buffering issues during long periods of listening. However, a value that’s too low might increase the buffer over time.</p>
+                        <p><input class="panel-33 input-text w-100 auto" type="number" style="min-height: 40px; color: var(--color-text); padding: 10px; padding-left: 10px; box-sizing: border-box; border: 2px solid transparent; font-family: 'Titillium Web', sans-serif;" id="audio-samplerateOffset" min="-10" max="10" step="1" value="0" aria-label="Samplerate offset"></p>
+                    </div>
+                </div>
             </div>
 
             <div class="panel-full m-0 tab-content no-bg" id="webserver" role="tabpanel">

--- a/web/wizard.ejs
+++ b/web/wizard.ejs
@@ -146,8 +146,16 @@
                     </div>
 
                     <div class="panel-100 no-bg text-center">
-                        <p>If you use an USB audio card on Linux, enabling this option might fix your audio issues.</p>
-                        <%- include('_components', {component: 'checkbox', cssClass: 'panel-100 flex-container flex-center', label: 'ALSA Software mode', id: 'audio-softwareMode'}) %>
+                        <div class="flex-container">
+                            <div class="panel-50 no-bg">
+                                <p>If you use an USB audio card on Linux, enabling this option might fix your audio issues.</p>
+                                <%- include('_components', {component: 'checkbox', cssClass: 'panel-100 flex-container flex-center', label: 'ALSA Software mode', id: 'audio-softwareMode'}) %>
+                            </div>
+                            <div class="panel-50 no-bg">
+                                <p>Legacy option for Linux / macOS that could resolve audio issues, but will consume additional CPU and RAM usage.</p>
+                                <%- include('_components', {component: 'checkbox', cssClass: 'panel-100 flex-container flex-center', label: 'Additional FFmpeg', id: 'audio-ffmpeg'}) %>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
/server/stream/index.js, 3las.server.js, checkFFmpeg.js

- Check for ffmpeg, fallback to ffmpeg-static if not found
- Remove additional ffmpeg instance (bkram)
- Check -ar sampling rate offset setting

setup.ejs
wizard.ejs
server_config.js

- Setup options for 'ffmpeg', 'samplerate offset'
