### PR TITLE
Don't output PI 0000 as filler on rds websocket

### DIFF
--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -354,7 +354,7 @@ function handleData(wss, receivedData, rdsWss) {
             // error correction, but this is a good substitute.
             errorsNew = (legacyRdsPiBuffer.length - 4) << 6;
           } else {
-            pi = '0000';
+            pi = '----';
             errorsNew = (0x03 << 6);
           }
 


### PR DESCRIPTION
Output four dashes instead of 0000 as a PI placeholder, for correct RDS Spy compatibility

Fixes #107 