### PR TITLE
Update serverTime to include TZ info

### DIFF
--- a/server/endpoints.js
+++ b/server/endpoints.js
@@ -352,10 +352,26 @@ router.get('/static_data', (req, res) => {
 });
 
 router.get('/server_time', (req, res) => {
-    const serverTime = new Date(); // Get current server time
-    const serverTimeUTC = new Date(serverTime.getTime() - (serverTime.getTimezoneOffset() * 60000)); // Adjust server time to UTC
+    const now = new Date();
+
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const hour = String(now.getHours()).padStart(2, '0');
+    const minute = String(now.getMinutes()).padStart(2, '0');
+    const second = String(now.getSeconds()).padStart(2, '0');
+    const millisecond = String(now.getMilliseconds()).padStart(3, '0');
+    
+    const offsetMinutes = -now.getTimezoneOffset();
+    const offsetSign = offsetMinutes >= 0 ? '+' : '-';
+    const offsetHours = String(Math.floor(Math.abs(offsetMinutes) / 60)).padStart(2, '0');
+    const offsetMins = String(Math.abs(offsetMinutes) % 60).padStart(2, '0');
+    const offset = `${offsetSign}${offsetHours}:${offsetMins}`;
+
+    const localIsoLike = `${year}-${month}-${day}T${hour}:${minute}:${second}.${millisecond}${offset}`;
+
     res.json({
-        serverTime: serverTimeUTC,
+        serverTime: localIsoLike
     });
 });
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -288,31 +288,28 @@ function getServerTime() {
         url: "./server_time",
         dataType: "json",
         success: function(data) {
-            const serverTimeUtc = data.serverTime;
-            
+            const serverTimeIso = data.serverTime;
+
+            const serverDate = new Date(serverTimeIso);
+
             const options = {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric',
                 hour: '2-digit',
                 minute: '2-digit',
-                hour12: false
+                hour12: false,
             };
-            
-            const serverOptions = {
-                ...options,
-                timeZone: 'Etc/UTC'
-            };
-            
-            const formattedServerTime = new Date(serverTimeUtc).toLocaleString(navigator.language ? navigator.language : 'en-US', serverOptions);
-            
-            $("#server-time").text(formattedServerTime);        
+
+            const localTime = serverDate.toLocaleString(navigator.language || 'en-US', options);
+
+            $("#server-time").text(localTime);        
         },
         error: function(jqXHR, textStatus, errorThrown) {
             console.error("Error fetching server time:", errorThrown);
         }
     });
-}  
+} 
 
 function sendPingRequest() {
     const timeoutDuration = 5000;


### PR DESCRIPTION
It will now display servertime like this:
serverTime: "2025-07-08T13:25:50.864+02:00"


In the expanded top panel, the time will still show local time as before.

This will make it easier for plugins to retrieve both local time and time in UTC.