### PR TITLE
Lowering audio boost to 1.7 in order to prevent saturation

### DIFF
--- a/server/stream/index.js
+++ b/server/stream/index.js
@@ -154,7 +154,7 @@ checkFFmpeg().then((ffmpegPath) => {
 
             // Apply audio boost if enabled
             if (serverConfig.audio.audioBoost) {
-                ffmpegArgs.splice(ffmpegArgs.indexOf('pipe:1'), 0, '-af', 'volume=2.5');
+                ffmpegArgs.splice(ffmpegArgs.indexOf('pipe:1'), 0, '-af', 'volume=1.7');
             }
 
             logDebug(`${consoleLogTitle} Launching FFmpeg with args: ${ffmpegArgs.join(' ')}`);
@@ -234,7 +234,7 @@ checkFFmpeg().then((ffmpegPath) => {
 
         // Apply audio boost if enabled and FFmpeg is used
         if (serverConfig.audio.audioBoost && serverConfig.audio.ffmpeg) {
-            commandDef.args.splice(commandDef.recArgs.indexOf('pipe:1'), 0, '-af', 'volume=2.5');
+            commandDef.args.splice(commandDef.recArgs.indexOf('pipe:1'), 0, '-af', 'volume=1.7');
         }
 
         function startRec() {
@@ -314,7 +314,7 @@ checkFFmpeg().then((ffmpegPath) => {
 
         // Apply audio boost if enabled and FFmpeg is used
         if (serverConfig.audio.audioBoost && serverConfig.audio.ffmpeg) {
-            commandDef.args.splice(commandDef.args.indexOf('pipe:1'), 0, '-af', 'volume=2.5');
+            commandDef.args.splice(commandDef.args.indexOf('pipe:1'), 0, '-af', 'volume=1.7');
         }
 
         function startArecord() {


### PR DESCRIPTION
1.7 is a very good value for the audio boost since the maximum audio output level is -3.0 / -2.5 dB on a signal respecting the 75 kHz excursion (frequency deviation).