### PR TITLE
Feat/proper macos audio device support

### DIFF
--- a/web/index.ejs
+++ b/web/index.ejs
@@ -176,6 +176,7 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
+                <span style="margin-left: 15px;" class="data-di tooltip" data-tooltip="" aria-label="Decoder Information">DI</span>
               </h3>
             </div>
           </div>
@@ -280,6 +281,9 @@
               </div>
             <div class="panel-75 hover-brighten no-bg-phone" id="rt-container" style="height: 100px;">
               <h2 style="margin-top: 4px;">RADIOTEXT</h2>
+              <div id="data-ptyn">
+                <span></span>
+              </div>
               <div id="data-rt0">
                 <span></span>
               </div>
@@ -334,6 +338,7 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
+          <span style="margin-left: 15px;" class="data-di tooltip" data-tooltip="" aria-label="Decoder Information">DI</span>
         </h3>
       </div>
     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -897,6 +897,8 @@ const $dataTa = $('.data-ta');
 const $dataMs = $('.data-ms');
 const $flagDesktopCointainer = $('#flags-container-desktop');
 const $dataPty = $('.data-pty');
+const $dataPtyn = $('#data-ptyn span');
+const $dataDi = $('.data-di');
 
 // Throttling function to limit the frequency of updates
 function throttle(fn, wait) {
@@ -994,7 +996,8 @@ const updateDataElements = throttle(function(parsedData) {
     
     updateHtmlIfChanged($dataRt0, processString(parsedData.rt0, parsedData.rt0_errors));
     updateHtmlIfChanged($dataRt1, processString(parsedData.rt1, parsedData.rt1_errors));
-    
+    updateHtmlIfChanged($dataPtyn, processString(parsedData.ptyn, parsedData.ptyn_errors));
+
     updateTextIfChanged($dataPty, rdsMode == 'true' ? usa_programmes[parsedData.pty] : europe_programmes[parsedData.pty]);
     
     if (parsedData.rds === true) {
@@ -1049,6 +1052,17 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
+        const diDesc = [
+            `Has Stereo: ${(parsedData.di & 0x8) ? 'Yes' : 'No'}`,
+            `Artificial Head: ${(parsedData.di & 0x4) ? 'Yes' : 'No'}`,
+            `Compressed: ${(parsedData.di & 0x2) ? 'Yes' : 'No'}`,
+            `Dynamic PTY: ${(parsedData.di & 0x1) ? 'Yes' : 'No'}`
+        ].join('<br>');
+        $dataDi
+            .html((parsedData.di & 0xF) === 0 ? "<span class='opacity-half'>DI</span>" : "DI")
+            .attr('data-tooltip', diDesc)
+            .data('tooltip', diDesc)
+            .attr('aria-label', diDesc.replace(/<br>/g, ', '));
     }
     
     if (updateCounter % 30 === 0) {


### PR DESCRIPTION
Now the USB descriptor in the headless tuner was fixed, it was possible to add `proper` audio device selection for macOS.

Also included the RDS PI changes.